### PR TITLE
hotfix: BigQuery and Mongodb connetion

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -55,13 +55,12 @@ module.exports = async function response(message, ctx=localCtx){
                 0,
                 'getMetadata',
                 metadata => metadata[0])
-            const columns = table.schema ? table.schema.fields.map(f => f.name) : []
+            
             const schema = flatten(raw).map(table => ({
                 schema: table.tableReference.datasetId,
                 name: table.tableReference.tableId,
-                columns,
+                columns: (table.schema && table.schema.fields ) ? table.schema.fields.map(f => f.name) : [],
             }))
-
             return {schema}
 
         } else {
@@ -84,7 +83,6 @@ async function createClient(db, credentials){
 }
 
 const { spawn } = require('child_process');
-const mongoShellToJSON = require('./mongo-shell').toStrict;
 
 async function createMongoClient(credentials){
     // mongodb://[username:password@]host1[:port1][,...hostN[:portN]]][/[database][?options]]


### PR DESCRIPTION
Mongodb
The mongoShellToJSON variable was never used, and it imported a nonexistent file called ./mongo-shell. So, I excluded the mongoShellToJSON declaration.

BigQuery
The columns variable used a table variable before that is created, so I changed the logic to get BigQuery table columns.